### PR TITLE
[fix] remove key insert from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # use prebuild alpine image with needed python packages from base branch
 FROM vojkovic/searxng:base
-ENV GID=991 UID=991 IMAGE_PROXY=true REDIS_URL= LIMITER= BASE_URL= NAME= PRIVACYPOLICY=https://search.vojkovic.xyz/privacy CONTACT=mailto:brockv@tuta.io ISSUE_URL=https://github.com/vojkovic/searxng/issues GIT_URL=https://github.com/vojkovic/searxng GIT_BRANCH=main PROXY1= PROXY2= PROXY3= \
+ENV GID=991 UID=991 IMAGE_PROXY=true REDIS_URL= LIMITER= BASE_URL= NAME= PROXY1= PROXY2= PROXY3= \
+PRIVACYPOLICY=https://search.vojkovic.xyz/privacy \
+CONTACT=mailto:brockv@tuta.io ISSUE_URL=https://github.com/vojkovic/searxng/issues \
+GIT_URL=https://github.com/vojkovic/searxng GIT_BRANCH=main \
 UPSTREAM_COMMIT=e5cc3e36ad5d075bef119aaa5994535a46633397
 WORKDIR /usr/local/searxng
 
@@ -21,7 +24,6 @@ COPY ./src/run.sh /usr/local/bin/run.sh
 RUN cp -r -v dockerfiles/uwsgi.ini /etc/uwsgi/; \
 chmod +x /usr/local/bin/run.sh; \
 sed -i -e "/safe_search:/s/0/1/g" \
--e "s/ultrasecretkey/$(openssl rand -hex 16)/g" \
 -e "/autocomplete:/s/\"\"/\"google\"/g" \
 -e "/autocomplete_min:/s/4/0/g" \
 -e "/port:/s/8888/8080/g" \

--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ This SearXNG instance is hosted on a VPS in Singapore. In December 2020, Qwant c
 
 * ```NAME``` : set the name of the instance, which is for example displayed in the title of the site (for example `SearXNG`)
 
+* ```PRIVACYPOLICY``` : set URL of privacy policy of the instance (for example `https://example.org/privacy-policy`)
+
 * ```CONTACT``` : set instance maintainer contact (for example `mailto:user@example.org`)
 
 * ```ISSUE_URL``` : set issue url for custom SearXNG repo (for example `https://github.com/vojkovic/searxng/issues` !Without trailing /)

--- a/src/run.sh
+++ b/src/run.sh
@@ -84,8 +84,5 @@ fi
 sed -i -e "s/ultrasecretkey/$(openssl rand -hex 16)/g" \
 searx/settings.yml
 
-# unset variables in running container
-unset MORTY_KEY
-
 # start uwsgi with SearXNG workload
 exec uwsgi --master --http-socket "0.0.0.0:8080" "/etc/uwsgi/uwsgi.ini"


### PR DESCRIPTION
* This is the main reason for the PR the other stuff is just some cleanup: in the Dockerfile the secret key got generated -> this means that the key replace in runtime is not going to work and everyone who has access to the image has also access to the secret key
* doc: add PRIVACYPOLICY var to readme
* add some newlines to the dockerfile ENV section to make it more readable
* remove unset of MORTY_KEY since morty is no longer supported